### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ Melange was developed with the following ideas in mind:
 
 ## Previews
 
-<img width="1326" alt="melange_dark_preview" src="https://user-images.githubusercontent.com/30883030/129780717-b97c788b-fbce-4e5a-be2d-f50c63eb7a7b.png">
+<img width="1326" alt="melange-dark-preview" src="https://user-images.githubusercontent.com/30883030/131925703-ac49ae5e-fee8-49e4-bee0-3dd61e2b03a9.png">
+<img width="1326" alt="melange-light-preview" src="https://user-images.githubusercontent.com/30883030/131925704-20ce9a8a-8a63-48a2-bd24-fb739c8201f9.png">
 
-<img width="1326" alt="melange_light_preview" src="https://user-images.githubusercontent.com/30883030/129780740-48f7c4bd-a53f-4614-9fb8-f21004e76f84.png">
-
-The font is [IBM/plex](https://github.com/IBM/plex) Mono Light
+The font is [IBM/plex](https://github.com/IBM/plex) Mono

--- a/colors/melange.vim
+++ b/colors/melange.vim
@@ -43,7 +43,7 @@ highlight NormalFloat guifg=NONE guibg=#38332E guisp=NONE gui=NONE blend=NONE
 highlight Number guifg=#D194BD guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight Operator guifg=#F7856E guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight PmenuSel guifg=NONE guibg=#544D45 guisp=NONE gui=NONE blend=NONE
-highlight PreProc guifg=#669966 guibg=NONE guisp=NONE gui=NONE blend=NONE
+highlight PreProc guifg=#94D194 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight Search guifg=#2A2622 guibg=#997733 guisp=NONE gui=NONE blend=NONE
 highlight Special guifg=#F7C96E guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight SpellBad guifg=#B34D4D guibg=NONE guisp=NONE gui=undercurl blend=NONE
@@ -55,16 +55,15 @@ highlight StatusLineNC guifg=#C9B39C guibg=#38332E guisp=NONE gui=NONE blend=NON
 highlight String guifg=#94A8D1 guibg=NONE guisp=NONE gui=italic blend=NONE
 highlight Substitute guifg=#2A2622 guibg=#997733 guisp=NONE gui=NONE blend=NONE
 highlight TSConstBuiltin guifg=#AD85AD guibg=NONE guisp=NONE gui=italic blend=NONE
-highlight TSError guifg=NONE guibg=NONE guisp=NONE gui=undercurl blend=NONE
-highlight TSKeywordFunction guifg=#94D194 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight TSMath guifg=#94D1D1 guibg=NONE guisp=NONE gui=NONE blend=NONE
+highlight TSNamespace guifg=#669966 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight TSPunctDelimiter guifg=#B34D4D guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight TSStrike guifg=NONE guibg=NONE guisp=NONE gui=strikethrough blend=NONE
 highlight TSStringEscape guifg=#5973A6 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight TSStrong guifg=NONE guibg=NONE guisp=NONE gui=bold blend=NONE
-highlight TSSymbol guifg=NONE guibg=NONE guisp=NONE gui=italic blend=NONE
+highlight TSSymbol guifg=#EDE6DE guibg=NONE guisp=NONE gui=italic blend=NONE
 highlight TSURI guifg=#94A8D1 guibg=NONE guisp=NONE gui=underline blend=NONE
-highlight TSVariableBuiltin guifg=NONE guibg=NONE guisp=NONE gui=italic blend=NONE
+highlight TSVariableBuiltin guifg=#EDE6DE guibg=NONE guisp=NONE gui=italic blend=NONE
 highlight TabLineSel guifg=NONE guibg=#38332E guisp=NONE gui=bold blend=NONE
 highlight Title guifg=#E09952 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight Todo guifg=#E09952 guibg=NONE guisp=NONE gui=bold blend=NONE
@@ -74,7 +73,6 @@ highlight VertSplit guifg=#544D45 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight Visual guifg=NONE guibg=#544D45 guisp=NONE gui=NONE blend=NONE
 highlight WarningMsg guifg=#B34D4D guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight Whitespace guifg=#544D45 guibg=NONE guisp=NONE gui=NONE blend=NONE
-highlight texMathZone guifg=#94D1D1 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight texTitleArg guifg=NONE guibg=NONE guisp=NONE gui=bold blend=NONE
 highlight! link CursorColumn ColorColumn
 highlight! link CursorLine ColorColumn
@@ -95,13 +93,15 @@ highlight! link SpecialKey Whitespace
 highlight! link StatusLine NormalFloat
 highlight! link TSConstMacro Constant
 highlight! link TSEmphasis Italic
-highlight! link TSEnviroment Statement
-highlight! link TSEnviromentName TSKeywordFunction
+highlight! link TSEnvironment Statement
+highlight! link TSEnvironmentName PreProc
 highlight! link TSFuncBuiltin Function
 highlight! link TSFuncMacro Function
+highlight! link TSKeywordFunction PreProc
 highlight! link TSPunctBracket Delimiter
 highlight! link TSPunctSpecial Delimiter
 highlight! link TSUnderline Underlined
+highlight! link TSVariable Identifier
 highlight! link TabLine StatusLineNC
 highlight! link TabLineFill StatusLine
 highlight! link WildMenu NormalFloat
@@ -109,8 +109,9 @@ highlight! link texFileArg Constant
 highlight! link texMathCmd Function
 highlight! link texMathDelim Delimiter
 highlight! link texMathDelimZone TSPunctDelimiter
-highlight! link texMathEnvArgName TSKeywordFunction
+highlight! link texMathEnvArgName PreProc
 highlight! link texMathSymbol Operator
+highlight! link texMathZone TSMath
 highlight! link texOptEqual Operator
 highlight! link texOptSep TSPunctDelimiter
 highlight! link texRefArg Constant
@@ -155,7 +156,7 @@ highlight NormalFloat guifg=NONE guibg=#F0E6DB guisp=NONE gui=NONE blend=NONE
 highlight Number guifg=#B34D90 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight Operator guifg=#AD1F1F guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight PmenuSel guifg=NONE guibg=#E0CCB8 guisp=NONE gui=NONE blend=NONE
-highlight PreProc guifg=#7AB87A guibg=NONE guisp=NONE gui=NONE blend=NONE
+highlight PreProc guifg=#339933 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight Search guifg=#F7F2ED guibg=#E0C285 guisp=NONE gui=NONE blend=NONE
 highlight Special guifg=#D99D26 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight SpellBad guifg=#D65C5C guibg=NONE guisp=NONE gui=undercurl blend=NONE
@@ -167,16 +168,15 @@ highlight StatusLineNC guifg=#856647 guibg=#F0E6DB guisp=NONE gui=NONE blend=NON
 highlight String guifg=#4D6EB3 guibg=NONE guisp=NONE gui=italic blend=NONE
 highlight Substitute guifg=#F7F2ED guibg=#E0C285 guisp=NONE gui=NONE blend=NONE
 highlight TSConstBuiltin guifg=#B87AB8 guibg=NONE guisp=NONE gui=italic blend=NONE
-highlight TSError guifg=NONE guibg=NONE guisp=NONE gui=undercurl blend=NONE
-highlight TSKeywordFunction guifg=#339933 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight TSMath guifg=#366363 guibg=NONE guisp=NONE gui=NONE blend=NONE
+highlight TSNamespace guifg=#7AB87A guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight TSPunctDelimiter guifg=#D65C5C guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight TSStrike guifg=NONE guibg=NONE guisp=NONE gui=strikethrough blend=NONE
 highlight TSStringEscape guifg=#8CA6D9 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight TSStrong guifg=NONE guibg=NONE guisp=NONE gui=bold blend=NONE
-highlight TSSymbol guifg=NONE guibg=NONE guisp=NONE gui=italic blend=NONE
+highlight TSSymbol guifg=#423324 guibg=NONE guisp=NONE gui=italic blend=NONE
 highlight TSURI guifg=#4D6EB3 guibg=NONE guisp=NONE gui=underline blend=NONE
-highlight TSVariableBuiltin guifg=NONE guibg=NONE guisp=NONE gui=italic blend=NONE
+highlight TSVariableBuiltin guifg=#423324 guibg=NONE guisp=NONE gui=italic blend=NONE
 highlight TabLineSel guifg=NONE guibg=#F0E6DB guisp=NONE gui=bold blend=NONE
 highlight Title guifg=#CC8033 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight Todo guifg=#CC8033 guibg=NONE guisp=NONE gui=bold blend=NONE
@@ -186,7 +186,6 @@ highlight VertSplit guifg=#E0CCB8 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight Visual guifg=NONE guibg=#E0CCB8 guisp=NONE gui=NONE blend=NONE
 highlight WarningMsg guifg=#D65C5C guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight Whitespace guifg=#E0CCB8 guibg=NONE guisp=NONE gui=NONE blend=NONE
-highlight texMathZone guifg=#366363 guibg=NONE guisp=NONE gui=NONE blend=NONE
 highlight texTitleArg guifg=NONE guibg=NONE guisp=NONE gui=bold blend=NONE
 highlight! link CursorColumn ColorColumn
 highlight! link CursorLine ColorColumn
@@ -207,13 +206,15 @@ highlight! link SpecialKey Whitespace
 highlight! link StatusLine NormalFloat
 highlight! link TSConstMacro Constant
 highlight! link TSEmphasis Italic
-highlight! link TSEnviroment Statement
-highlight! link TSEnviromentName TSKeywordFunction
+highlight! link TSEnvironment Statement
+highlight! link TSEnvironmentName PreProc
 highlight! link TSFuncBuiltin Function
 highlight! link TSFuncMacro Function
+highlight! link TSKeywordFunction PreProc
 highlight! link TSPunctBracket Delimiter
 highlight! link TSPunctSpecial Delimiter
 highlight! link TSUnderline Underlined
+highlight! link TSVariable Identifier
 highlight! link TabLine StatusLineNC
 highlight! link TabLineFill StatusLine
 highlight! link WildMenu NormalFloat
@@ -221,8 +222,9 @@ highlight! link texFileArg Constant
 highlight! link texMathCmd Function
 highlight! link texMathDelim Delimiter
 highlight! link texMathDelimZone TSPunctDelimiter
-highlight! link texMathEnvArgName TSKeywordFunction
+highlight! link texMathEnvArgName PreProc
 highlight! link texMathSymbol Operator
+highlight! link texMathZone TSMath
 highlight! link texOptEqual Operator
 highlight! link texOptSep TSPunctDelimiter
 highlight! link texRefArg Constant

--- a/lua/melange/init.lua
+++ b/lua/melange/init.lua
@@ -292,11 +292,11 @@ TSPunctSpecial       { Delimiter };
 -- TSString             { };
 -- TSStringRegex        { };
 TSStringEscape       { fg=c.blue };
-TSSymbol             { gui=it };
+TSSymbol             { Identifier, gui=it };
 -- TSType               { };
 -- TSTypeBuiltin        { };
--- TSVariable           { };
-TSVariableBuiltin    { gui=it };
+TSVariable           { Identifier };
+TSVariableBuiltin    { Identifier, gui=it };
 
 -- TSTag                { };
 -- TSTagDelimiter       { };

--- a/lua/melange/init.lua
+++ b/lua/melange/init.lua
@@ -264,7 +264,7 @@ Todo           { fg=c.yellow, gui=bf };
 TSConstBuiltin       { Constant, gui=it };
 TSConstMacro         { Constant };
 -- TSConstructor        { };
-TSError              { gui=undercurl };
+-- TSError              { gui=undercurl };
 -- TSException          { };
 -- TSField              { };
 -- TSFloat              { };

--- a/lua/melange/init.lua
+++ b/lua/melange/init.lua
@@ -13,6 +13,7 @@
 --  "Y8P"  "Y888888P'"Y88P"`Y8P' "YY8P8P88P     `Y8
 --
 
+-- vim.opt.keywordprg=":help"  --Jump easily to hl-groups docs.
 
 local lush = require("lush")
 local hsl = lush.hsl
@@ -31,7 +32,7 @@ palette.dark = {
 
     shades = {
         red     = hsl(  0, 40, 30);
-        yellow  = hsl( 40, 50, 40); -- amber
+        yellow  = hsl( 40, 50, 40);
         green   = hsl(120, 30, 20);
         cyan    = hsl(180, 30, 20);
         blue    = hsl(220, 30, 20);
@@ -40,7 +41,7 @@ palette.dark = {
 
     tones = {
         red     = hsl(  0, 40, 50);
-        yellow  = hsl( 30, 70, 60); -- orange
+        yellow  = hsl( 30, 70, 60);  --orange
         green   = hsl(120, 20, 50);
         cyan    = hsl(180, 20, 60);
         blue    = hsl(220, 30, 50);
@@ -48,7 +49,7 @@ palette.dark = {
     };
 
     tints = {
-        red     = hsl( 10, 90, 70); -- salmon
+        red     = hsl( 10, 90, 70);
         yellow  = hsl( 40, 90, 70);
         green   = hsl(120, 40, 70);
         cyan    = hsl(180, 40, 70);
@@ -99,11 +100,11 @@ local bg = vim.opt.background:get()
 local g = palette[bg].grays
 local c = palette[bg].tones
 
-local d, b; -- TODO: Rename
-if bg == "dark" then --shades are backgrounds, and tints foregrounds
+local d, b;  --TODO: REname
+if bg == "dark" then  --shades are backgrounds, and tints foregrounds
     d = palette[bg].shades
     b = palette[bg].tints
-elseif bg == "light" then --tints are backgrounds, and shades foregrounds
+elseif bg == "light" then  --tints are backgrounds, and shades foregrounds
     d = palette[bg].tints
     b = palette[bg].shades
 end
@@ -124,64 +125,64 @@ return lush(function() return {
 
 ---- :help highlight-default -------------------------------
 
-Normal       { fg=g.fg, bg=g.bg };                          -- Normal text
-NormalFloat  { bg=g.overbg };                               -- Normal text in floating windows
--- NormalNC     { };                                        -- Normal text in non-current windows
+Normal       { fg=g.fg, bg=g.bg };
+NormalFloat  { bg=g.overbg };
+-- NormalNC     { };
 
--- Cursor       { };                                        -- Character under the cursor
--- lCursor      { };                                        -- The character under the cursor when |language-mapping| is used (see 'guicursor')
--- CursorIM     { };                                        -- Like Cursor, but used when in IME mode |CursorIM|
--- TermCursor   { };                                        -- Cursor in a focused terminal
--- TermCursorNC { };                                        -- Cursor in an unfocused terminal
+-- Cursor       { };
+-- lCursor      { };
+-- CursorIM     { };
+-- TermCursor   { };
+-- TermCursorNC { };
 
-ColorColumn  { bg=g.overbg };                               -- Used for the columns set with 'colorcolumn'
-CursorColumn { ColorColumn };                               -- Screen-column at the cursor, when 'cursorcolumn' is set
-CursorLine   { ColorColumn };                               -- Screen-line at the cursor, when 'cursorline' is set
-VertSplit    { fg=g.sel };                                  -- The column separating vertically split windows
+ColorColumn  { bg=g.overbg };
+CursorColumn { ColorColumn };
+CursorLine   { ColorColumn };
+VertSplit    { fg=g.sel };
 
-LineNr       { fg=g.sel };                                  -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set
-CursorLineNr { fg=c.yellow };                               -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line
+LineNr       { fg=g.sel };
+CursorLineNr { fg=c.yellow };
 
-Folded       { fg=g.com, bg=g.overbg };                     -- Line used for closed folds
-FoldColumn   { LineNr };                                    -- 'foldcolumn'
-SignColumn   { LineNr };                                    -- Column where |signs| are displayed
+Folded       { fg=g.com, bg=g.overbg };
+FoldColumn   { LineNr };
+SignColumn   { LineNr };
 
-Pmenu        { NormalFloat };                               -- normal item
-PmenuSel     { bg=g.sel };                                  -- selected item
-PmenuSbar    { Pmenu };                                     -- scrollbar
-PmenuThumb   { PmenuSel };                                  -- Thumb of the scrollbar
+Pmenu        { NormalFloat };
+PmenuSel     { bg=g.sel };
+PmenuSbar    { Pmenu };
+PmenuThumb   { PmenuSel };
 
-StatusLine   { NormalFloat };                               -- status line of current window
-StatusLineNC { StatusLine, fg=g.faded };                    -- status lines of not-current windows
-WildMenu     { NormalFloat };                               -- current match in 'wildmenu' completion
+StatusLine   { NormalFloat };
+StatusLineNC { StatusLine, fg=g.faded };
+WildMenu     { NormalFloat };
 
-TabLine      { StatusLineNC };                              -- not active tab page label
-TabLineFill  { StatusLine };                                -- where there are no labels
-TabLineSel   { StatusLine, gui=bf };                        -- active tab page label
+TabLine      { StatusLineNC };
+TabLineFill  { StatusLine };
+TabLineSel   { StatusLine, gui=bf };
 
-MatchParen   { fg=b.yellow, bg=g.sel, gui=bf };             -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
-Substitute   { fg=g.bg, bg=d.yellow };                      -- |:substitute| replacement text highlighting
-Search       { fg=g.bg, bg=d.yellow };                      -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
--- QuickFixLine { };                                        -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
--- IncSearch    { };                                        -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
-Visual       { bg=g.sel };                                  -- Visual mode selection
--- VisualNOS    { };                                        -- Visual mode selection when vim is "Not Owning the Selection".
+MatchParen   { fg=b.yellow, bg=g.sel, gui=bf };
+Substitute   { fg=g.bg, bg=d.yellow };
+Search       { fg=g.bg, bg=d.yellow };
+-- QuickFixLine { };
+-- IncSearch    { };
+Visual       { bg=g.sel };
+-- VisualNOS    { };
 
-Conceal      { fg=g.faded };                                -- Placeholder characters substituted for concealed text (see 'conceallevel')
-Whitespace   { fg=g.sel };                                  -- "nbsp", "space", "tab" and "trail" in 'listchars'
-EndOfBuffer  { Whitespace };                                -- Filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
-NonText      { Whitespace };                                -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
-SpecialKey   { Whitespace };                                -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace|
+Conceal      { fg=g.faded };
+Whitespace   { fg=g.sel };
+EndOfBuffer  { Whitespace };
+NonText      { Whitespace };
+SpecialKey   { Whitespace };
 
-Directory    { fg=c.yellow };                               -- directory names (and other special names in listings)
-Title        { fg=c.yellow };                               -- titles for output from ":set all", ":autocmd" etc.
-ErrorMsg     { bg=d.red };                                  -- error messages on the command line
-ModeMsg      { fg=g.faded };                                -- 'showmode' message (e.g., "-- INSERT -- ")
--- MsgArea      { };                                        -- Area for messages and cmdline
--- MsgSeparator { };                                        -- Separator for scrolled messages, `msgsep` flag of 'display'
-MoreMsg      { fg=c.green, gui=bf };                        -- |more-prompt|
-WarningMsg   { fg=c.red };                                  -- warning messages
-Question     { MoreMsg };                                   -- |hit-enter| prompt and yes/no questions
+Directory    { fg=c.yellow };
+Title        { fg=c.yellow };
+ErrorMsg     { bg=d.red };
+ModeMsg      { fg=g.faded };
+-- MsgArea      { };
+-- MsgSeparator { };
+MoreMsg      { fg=c.green, gui=bf };
+WarningMsg   { fg=c.red };
+Question     { MoreMsg };
 
 
 ---- :help :diff -------------------------------------------
@@ -201,7 +202,6 @@ SpellBad     { fg=c.red,    gui=undercurl };
 SpellCap     { fg=c.blue,   gui=undercurl };
 SpellLocal   { fg=c.yellow, gui=undercurl };
 SpellRare    { fg=b.yellow, gui=undercurl };
-
 
 
 ---- :help group-name --------------------------------------
@@ -252,107 +252,104 @@ Error          { bg=d.red };
 Todo           { fg=c.yellow, gui=bf };
 
 
+---- :help nvim-treesitter-highlights (external plugin) ----
 
----- :help nvim-treesitter-highlights ----------------------
-
--- TSAnnotation         { };                                -- For C++/Dart attributes, annotations that can be attached to the code to denote some kind of meta information.
--- TSAttribute          { };                                -- (unstable) TODO: docs
+-- TSAnnotation         { };
+-- TSAttribute          { };
 -- TSBoolean            { };
 -- TSCharacter          { };
 -- TSComment            { };
--- TSConditional        { };                                -- keywords related to conditionnals.
+-- TSConditional        { };
 -- TSConstant           { };
-TSConstBuiltin       { Constant, gui=it };                  -- constant that are built in the language: `nil` in Lua.
-TSConstMacro         { Constant };                          -- constants that are defined by macros: `NULL` in C.
--- TSConstructor        { };                                -- constructor calls and definitions: ` { }` in Lua, and Java constructors.
-TSError              { gui=undercurl };                     -- syntax/parser errors.
--- TSException          { };                                -- exception related keywords.
+TSConstBuiltin       { Constant, gui=it };
+TSConstMacro         { Constant };
+-- TSConstructor        { };
+TSError              { gui=undercurl };
+-- TSException          { };
 -- TSField              { };
 -- TSFloat              { };
--- TSFunction           { };                                -- function (calls and definitions).
-TSFuncBuiltin        { Function };                          -- builtin functions: `table.insert` in Lua.
-TSFuncMacro          { Function };                          -- macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
--- TSInclude            { };                                -- includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
--- TSKeyword            { };                                -- keywords that don't fall in previous categories.
-TSKeywordFunction    { fg=b.green };                        -- keywords used to define a fuction.
--- TSKeywordOperator    { };                                -- operators that are English words, e.g. `and`, `as`, `or`.
--- TSKeywordReturn      { };                                -- `return` and `yield` keywords.
--- TSLabel              { };                                -- labels: `label:` in C and `:label:` in Lua.
--- TSMethod             { };                                -- method calls and definitions.
--- TSNamespace          { };                                -- identifiers referring to modules and namespaces.
--- TSNone               { };                                -- no highlighting.
+-- TSFunction           { };
+TSFuncBuiltin        { Function };
+TSFuncMacro          { Function };
+-- TSInclude            { };
+-- TSKeyword            { };
+TSKeywordFunction    { fg=b.green };
+-- TSKeywordOperator    { };
+-- TSKeywordReturn      { };
+-- TSLabel              { };
+-- TSMethod             { };
+-- TSNamespace          { };
+-- TSNone               { };
 -- TSNumber             { };
--- TSOperator           { };                                -- any operator: `+`, but also `->` and `*` in C.
--- TSParameter          { };                                -- parameters of a function.
--- TSParameterReference { };                                -- references to parameters of a function.
--- TSProperty           { };                                -- Same as `TSField`.
-TSPunctDelimiter     { fg=c.red };                          -- delimiters ie: `.`
-TSPunctBracket       { Delimiter };                         -- brackets and parentheses.
-TSPunctSpecial       { Delimiter };                         -- special punctutation that does not fall in the catagories before.
--- TSRepeat             { };                                -- keywords related to loops.
+-- TSOperator           { };
+-- TSParameter          { };
+-- TSParameterReference { };
+-- TSProperty           { };
+TSPunctDelimiter     { fg=c.red };
+TSPunctBracket       { Delimiter };
+TSPunctSpecial       { Delimiter };
+-- TSRepeat             { };
 -- TSString             { };
 -- TSStringRegex        { };
-TSStringEscape       { fg=c.blue };                         -- escape characters within a string.
-TSSymbol             { gui=it };                            -- identifiers referring to symbols or atoms.
+TSStringEscape       { fg=c.blue };
+TSSymbol             { gui=it };
 -- TSType               { };
 -- TSTypeBuiltin        { };
--- TSVariable           { };                                -- Any variable name that does not have another highlight.
-TSVariableBuiltin    { gui=it };                            -- Variable names that are defined by the languages, like `this` or `self`.
+-- TSVariable           { };
+TSVariableBuiltin    { gui=it };
 
--- TSTag                { };                                -- Tags like html tag names.
--- TSTagDelimiter       { };                                -- Tag delimiter like `<` `>` `/`
--- TSText               { };                                -- strings considered text in a markup language.
-TSStrong             { gui=bf };                            -- text to be represented in bold.
-TSEmphasis           { Italic };                            -- text to be represented with emphasis.
-TSUnderline          { Underlined };                        -- text to be represented with an underline.
-TSStrike             { gui="strikethrough" };               -- strikethrough text.
--- TSTitle              { };                                -- Text that is part of a title.
+-- TSTag                { };
+-- TSTagDelimiter       { };
+-- TSText               { };
+TSStrong             { gui=bf };
+TSEmphasis           { Italic };
+TSUnderline          { Underlined };
+TSStrike             { gui="strikethrough" };
+-- TSTitle              { };
 -- TSLiteral            { };
-TSURI                { String, gui=underline };             -- Any URI like a link or email.
-TSMath               { fg=b.cyan };                         -- LaTeX-like math environments.
--- TSTextReference      { };                                -- footnotes, text references, citations.
-TSEnviroment         { Statement };                         -- text environments of markup languages.
-TSEnviromentName     { TSKeywordFunction };                 -- name/string indicating the type of text environment.
--- TSNote               { };                                -- Text representation of an informational note.
--- TSWarning            { };                                -- Text representation of a warning note.
--- TSDanger             { };                                -- Text representation of a danger note.
-
+TSURI                { String, gui=underline };
+TSMath               { fg=b.cyan };
+-- TSTextReference      { };
+TSEnviroment         { Statement };
+TSEnviromentName     { TSKeywordFunction };
+-- TSNote               { };
+-- TSWarning            { };
+-- TSDanger             { };
 
 
 ---- :help lsp-highlight -----------------------------------
 
-LspReferenceText                     { Visual };            -- highlighting "text" references
-LspReferenceRead                     { Visual };            -- highlighting "read" references
-LspReferenceWrite                    { Visual };            -- highlighting "write" references
+LspReferenceText                     { Visual };
+LspReferenceRead                     { Visual };
+LspReferenceWrite                    { Visual };
 
-LspDiagnosticsDefaultError           { fg=c.red };          -- base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
-LspDiagnosticsDefaultWarning         { fg=b.yellow };       -- base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
-LspDiagnosticsDefaultInformation     { fg=b.blue };         -- base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
-LspDiagnosticsDefaultHint            { fg=c.green};         -- base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+LspDiagnosticsDefaultError           { fg=c.red };
+LspDiagnosticsDefaultWarning         { fg=b.yellow };
+LspDiagnosticsDefaultInformation     { fg=b.blue };
+LspDiagnosticsDefaultHint            { fg=c.green};
 
--- LspDiagnosticsVirtualTextError       { };                -- "Error" diagnostic virtual text
--- LspDiagnosticsVirtualTextWarning     { };                -- "Warning" diagnostic virtual text
--- LspDiagnosticsVirtualTextInformation { };                -- "Information" diagnostic virtual text
--- LspDiagnosticsVirtualTextHint        { };                -- "Hint" diagnostic virtual text
+-- LspDiagnosticsVirtualTextError       { };
+-- LspDiagnosticsVirtualTextWarning     { };
+-- LspDiagnosticsVirtualTextInformation { };
+-- LspDiagnosticsVirtualTextHint        { };
 
-LspDiagnosticsUnderlineError         { gui=undercurl };     -- underline "Error" diagnostics
-LspDiagnosticsUnderlineWarning       { gui=undercurl };     -- underline "Warning" diagnostics
-LspDiagnosticsUnderlineInformation   { gui=undercurl };     -- underline "Information" diagnostics
-LspDiagnosticsUnderlineHint          { gui=undercurl };     -- underline "Hint" diagnostics
+LspDiagnosticsUnderlineError         { gui=undercurl };
+LspDiagnosticsUnderlineWarning       { gui=undercurl };
+LspDiagnosticsUnderlineInformation   { gui=undercurl };
+LspDiagnosticsUnderlineHint          { gui=undercurl };
 
--- LspDiagnosticsFloatingError          { };                -- color "Error" diagnostic messages in diagnostics float
--- LspDiagnosticsFloatingWarning        { };                -- color "Warning" diagnostic messages in diagnostics float
--- LspDiagnosticsFloatingInformation    { };                -- color "Information" diagnostic messages in diagnostics float
--- LspDiagnosticsFloatingHint           { };                -- color "Hint" diagnostic messages in diagnostics float
+-- LspDiagnosticsFloatingError          { };
+-- LspDiagnosticsFloatingWarning        { };
+-- LspDiagnosticsFloatingInformation    { };
+-- LspDiagnosticsFloatingHint           { };
 
--- LspDiagnosticsSignError              { };                -- "Error" signs in sign column
--- LspDiagnosticsSignWarning            { };                -- "Warning" signs in sign column
--- LspDiagnosticsSignInformation        { };                -- "Information" signs in sign column
--- LspDiagnosticsSignHint               { };                -- "Hint" signs in sign column
+-- LspDiagnosticsSignError              { };
+-- LspDiagnosticsSignWarning            { };
+-- LspDiagnosticsSignInformation        { };
+-- LspDiagnosticsSignHint               { };
 
 
-
---- :help vimtex-syntax-reference --------------------------
+--- :help vimtex-syntax-reference (external plugin) --------
 
 texOptSep            { TSPunctDelimiter };
 texOptEqual          { Operator };
@@ -368,13 +365,11 @@ texMathDelim         { Delimiter };
 texMathEnvArgName    { TSKeywordFunction };
 
 
-
----- Other Vim groups --------------------------------------
+---- Misc. -------------------------------------------------
 HelpHyperTextJump    { fg=c.yellow };
 
 
-
----- Metagroup (basically a hack for builds) ---------------
+---- Metagroup (hack for builds) ---------------------------
 Melange { lush = palette[bg] };
 
 }end)

--- a/lua/melange/init.lua
+++ b/lua/melange/init.lua
@@ -183,12 +183,19 @@ MoreMsg      { fg=c.green, gui=bf };                        -- |more-prompt|
 WarningMsg   { fg=c.red };                                  -- warning messages
 Question     { MoreMsg };                                   -- |hit-enter| prompt and yes/no questions
 
+
+---- :help :diff -------------------------------------------
+
 DiffAdd      { bg=d.green };
-DiffAdded    { DiffAdd };
-DiffDelete   { bg=d.red };
-DiffRemoved  { DiffDelete };
 DiffChange   { bg=d.magenta };
+DiffDelete   { bg=d.red };
 DiffText     { bg=d.blue };
+
+DiffAdded    { DiffAdd };
+DiffRemoved  { DiffDelete };
+
+
+---- :help spell -------------------------------------------
 
 SpellBad     { fg=c.red,    gui=undercurl };
 SpellCap     { fg=c.blue,   gui=undercurl };

--- a/lua/melange/init.lua
+++ b/lua/melange/init.lua
@@ -225,7 +225,7 @@ Operator       { fg=b.red };
 -- Keyword        { };
 -- Exception      { };
 
-PreProc        { fg=c.green };
+PreProc        { fg=b.green };
 -- Include        { };
 -- Define         { };
 -- Macro          { };
@@ -273,12 +273,12 @@ TSFuncBuiltin        { Function };
 TSFuncMacro          { Function };
 -- TSInclude            { };
 -- TSKeyword            { };
-TSKeywordFunction    { fg=b.green };
+TSKeywordFunction    { PreProc };
 -- TSKeywordOperator    { };
 -- TSKeywordReturn      { };
 -- TSLabel              { };
 -- TSMethod             { };
--- TSNamespace          { };
+TSNamespace          { fg=c.green };
 -- TSNone               { };
 -- TSNumber             { };
 -- TSOperator           { };
@@ -310,8 +310,8 @@ TSStrike             { gui="strikethrough" };
 TSURI                { String, gui=underline };
 TSMath               { fg=b.cyan };
 -- TSTextReference      { };
-TSEnviroment         { Statement };
-TSEnviromentName     { TSKeywordFunction };
+TSEnvironment        { Statement };
+TSEnvironmentName    { PreProc };
 -- TSNote               { };
 -- TSWarning            { };
 -- TSDanger             { };
@@ -359,10 +359,10 @@ texRefArg            { Constant };
 
 texMathCmd           { Function };
 texMathSymbol        { Operator };
-texMathZone          { fg=b.cyan };
+texMathZone          { TSMath };
 texMathDelimZone     { TSPunctDelimiter };
 texMathDelim         { Delimiter };
-texMathEnvArgName    { TSKeywordFunction };
+texMathEnvArgName    { PreProc };
 
 
 ---- Misc. -------------------------------------------------


### PR DESCRIPTION
- Remove TSError (Fix #21)
- Change PreProc green
  - use primary green for keywords that "introduce" a scope (functions and modules)
  - use secondary green for namespace identifiers themselves (e.g. `std` in Rust/C++)
- Fix TSVariable highlights missing in certain contexts

-----
- remove comments. use `keywordprg`