### PR TITLE
Add terminator term

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [Kitty](https://github.com/kovidgoyal/kitty)
   - [Wezterm](https://github.com/wez/wezterm)
   - [iTerm2](https://github.com/gnachman/iTerm2)
+  - [terminator](https://github.com/gnome-terminator/terminator)
 
 
 ## Requirements

--- a/lua/melange/build.lua
+++ b/lua/melange/build.lua
@@ -112,10 +112,11 @@ local function build(terminals)
 end
 
 local terminals = {
-    alacritty = {ext=".yml"},
-    kitty     = {ext=".conf"},
-    termite   = {ext=""},
-    wezterm   = {ext=".toml"},
+    alacritty  = {ext=".yml"},
+    kitty      = {ext=".conf"},
+    terminator = {ext=".config"},
+    termite    = {ext=""},
+    wezterm    = {ext=".toml"},
 }
 
 terminals.alacritty.template = [[
@@ -172,6 +173,14 @@ color13 $brmagenta
 color14 $brcyan
 color15 $brwhite
 ]]
+
+terminals.terminator.template = [=[
+ [[melange]]
+    background_color = "$bg"
+    cursor_color = "$fg"
+    foreground_color = "$fg"
+    palette = "$black:$red:$green:$yellow:$blue:$magenta:$cyan:$white:$brblack:$brred:$brgreen:$bryellow:$brblue:$brmagenta:$brcyan:$brwhite"
+]=]
 
 terminals.termite.template = [[
 [colors]


### PR DESCRIPTION
This adds the [terminator](https://launchpad.net/terminator) terminal to the build script.

Unfortunately, I wasn't able to actually build the themes, since

- My nvim version is < 0.5
- I'm too new to lua to know the ecosystem well enough to run the build script manually (it would be cool if running `make` was automated with a GitHub Workflow :slightly_smiling_face: )

Hopefully this PR is acceptable!

Also, with your permission, I'd like to add melange to https://github.com/EliverLara/terminator-themes, too.