### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = LF
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.itermcolors]
+indent_style = tab
+indent_size = none
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.md]
+indent_style = none
+indent_size = none
+
+[{M,m}akefile]
+indent_style = tab
+indent_size = none


### PR DESCRIPTION
While working on #39 I noticed that my editor wasn't indenting consistently with existing indents.

This adds an [`.editorconfig`](https://editorconfig.org/) file, which should help keep basic styling consistent with [any editor with EditorConfig support](https://editorconfig.org/#pre-installed).