### PR TITLE
Add foot terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
 - Support for various terminal emulators:
   - [Alacritty](https://github.com/alacritty/alacritty)
+  - [foot](https://codeberg.org/dnkl/foot)
   - [Kitty](https://github.com/kovidgoyal/kitty)
   - [Wezterm](https://github.com/wez/wezterm)
   - [iTerm2](https://github.com/gnachman/iTerm2)

--- a/lua/melange/build.lua
+++ b/lua/melange/build.lua
@@ -155,6 +155,7 @@ end
 
 local terminals = {
   alacritty = { ext = '.yml' },
+  foot = { ext = '.ini' },
   kitty = { ext = '.conf' },
   terminator = { ext = '.config' },
   termite = { ext = '' },
@@ -184,6 +185,30 @@ colors:
     magenta: '$brmagenta'
     cyan:    '$brcyan'
     white:   '$brwhite'
+]]
+
+terminals.foot.template = [[
+[colors]
+foreground = $fg
+background = $bg
+selection-background = $brblack
+selection-foreground = $fg
+regular0   = $black
+regular1   = $red
+regular2   = $green
+regular3   = $yellow
+regular4   = $blue
+regular5   = $magenta
+regular6   = $cyan
+regular7   = $white
+bright0    = $brblack
+bright1    = $brred
+bright2    = $brgreen
+bright3    = $bryellow
+bright4    = $brblue
+bright5    = $brmagenta
+bright6    = $brcyan
+bright7    = $brwhite
 ]]
 
 terminals.kitty.template = [[


### PR DESCRIPTION
I did not add the generated config files because I wasn't able to run the build script:

`make` gives `E5108: Error executing lua [string ":lua"]:1: module 'melange.build' not found`

When I run `:lua require("melange.build").build()` in neovim I get

```
E5108: Error executing lua Vim:E686: Argument of sort() must be a List
stack traceback:
        [C]: in function 'sort'
        .../.local/share/nvim/plugged/melange/lua/melange/build.lua:134: in function 'build_viml'
        .../.local/share/nvim/plugged/melange/lua/melange/build.lua:266: in function 'build'
        [string ":lua"]:1: in main chunk
```

This is on neovim v0.8.1 and melange was installed with vim-plug.