### PR TITLE
feat: add vimtex highlight texItemLabelConcealed

### DIFF
--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -333,6 +333,8 @@ for name, attrs in pairs {
   texMathDelim = 'Delimiter',
   texMathEnvArgName = 'PreProc',
 
+  texItemLabelConcealed = '@label',
+
   --- neo-tree highlights  :help neo-tree-highlights ---
 
   NeoTreeNormal = 'NormalFloat',


### PR DESCRIPTION
There's an undocumented syntax group of VimTeX, `texItemLabelConcealed`. The labels of items in `itemize`-like environments, after concealing, is set to this group.

The item label is in general different to the normal texts, and should be highlighted differently. This commit sets the highlight group `@label` for that.