### PR TITLE
feat(color): add support for rainbow-delimiters.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [lightline.vim](https://github.com/itchyny/lightline.vim)
   - [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim)
   - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
+  - [rainbow-delimiters.nvim](https://github.com/hiphish/rainbow-delimiters.nvim)
 - Support for various terminal emulators (see [`term/`](term/)):
   - [Alacritty](https://github.com/alacritty/alacritty)
   - [Foot](https://codeberg.org/dnkl/foot)

--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -395,6 +395,16 @@ for name, attrs in pairs {
   CmpItemKindConstant = '@constant',
   CmpItemKindColor = '@constant',
   CmpItemKindClass = '@type',
+
+  ---- :help rb-delimiters-colors (rainbow-delimiters.nvim) --
+
+  RainbowDelimiterRed = { fg = b.red },
+  RainbowDelimiterYellow = { fg = b.yellow },
+  RainbowDelimiterBlue = { fg = b.blue },
+  RainbowDelimiterOrange = { fg = c.yellow },
+  RainbowDelimiterGreen = { fg = b.green },
+  RainbowDelimiterViolet = { fg = c.magenta },
+  RainbowDelimiterCyan = { fg = b.cyan },
 } do
   if type(attrs) == 'table' then
     vim.api.nvim_set_hl(0, name, attrs)


### PR DESCRIPTION
GitHub repo: https://github.com/hiphish/rainbow-delimiters.nvim

## Checklist for Plugins

Paste link to documentation listing highlight groups:

- [x] (In `colors/melange.lua`) Add highlight groups
- [x] (In `README.md`) Add link to plugin source repository

