### PR TITLE
Added support for nvim-notify higlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim)
   - [rainbow-delimiters.nvim](https://github.com/hiphish/rainbow-delimiters.nvim)
   - [VimTeX](https://github.com/lervag/vimtex)
+  - [nvim-notify](https://github.com/rcarriga/nvim-notify.git)
 - Support for various terminal emulators/multiplexers (see [`term/`](term/)):
   - [Alacritty](https://github.com/alacritty/alacritty)
   - [Foot](https://codeberg.org/dnkl/foot)

--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -640,6 +640,29 @@ for name, attrs in pairs {
   RainbowDelimiterGreen = { fg = b.green },
   RainbowDelimiterViolet = { fg = c.magenta },
   RainbowDelimiterCyan = { fg = b.cyan },
+
+  ---- "rcarriga/nvim-notify" https://github.com/rcarriga/nvim-notify?tab=readme-ov-file#highlights
+
+  NotifyERRORBorder = { fg = c.red },
+  NotifyWARNBorder = { fg = c.yellow },
+  NotifyINFOBorder = { fg = c.green },
+  NotifyDEBUGBorder = { fg = a.fg },
+  NotifyTRACEBorder = { fg = c.magenta },
+  NotifyERRORIcon = { fg = b.red },
+  NotifyWARNIcon = { fg = b.yellow },
+  NotifyINFOIcon = { fg = b.green },
+  NotifyDEBUGIcon = { fg = a.fg },
+  NotifyTRACEIcon = { fg = b.magenta },
+  NotifyERRORTitle = { fg = b.red },
+  NotifyWARNTitle = { fg = b.yellow },
+  NotifyINFOTitle = { fg = b.green },
+  NotifyDEBUGTitle = { fg = a.fg },
+  NotifyTRACETitle = { fg = b.magenta },
+  NotifyERRORBody = 'Normal',
+  NotifyWARNBody = 'Normal',
+  NotifyINFOBody = 'Normal',
+  NotifyDEBUGBody = 'Normal',
+  NotifyTRACEBody = 'Normal',
 } do
   if type(attrs) == 'table' then
     vim.api.nvim_set_hl(0, name, attrs)


### PR DESCRIPTION
## Checklist for Plugins <!-- Remove if PR is for a terminal emulator -->

Paste link to documentation listing highlight groups:

- [x] (In `colors/melange.lua`) Write help file that lists the highlight groups
- [x] (In `colors/melange.lua`) Add highlight groups
- [x] (In `README.md`) Add link to plugin source repository


Here's how it looks:
<img width="632" height="131" alt="Screenshot 2025-07-22 at 12 31 00" src="https://github.com/user-attachments/assets/26117d8d-441f-4a32-a56e-0b588455e17f" />
<img width="632" height="131" alt="Screenshot 2025-07-22 at 12 31 26" src="https://github.com/user-attachments/assets/157579b1-5eb6-4788-a64e-139cea551678" />
<img width="632" height="132" alt="Screenshot 2025-07-22 at 12 31 43" src="https://github.com/user-attachments/assets/1beb558e-ec57-4e3c-9750-732ee6378978" />
<img width="633" height="131" alt="Screenshot 2025-07-22 at 12 32 02" src="https://github.com/user-attachments/assets/f3a509a2-8bc7-4b8a-9135-4bc2113db88e" />
<img width="634" height="130" alt="Screenshot 2025-07-22 at 12 32 37" src="https://github.com/user-attachments/assets/13bf1f4a-41a7-486b-b7c8-3f4485f3c041" />

